### PR TITLE
Fix the resize and update the new contrastive loss

### DIFF
--- a/qdtrack/datasets/pipelines/transforms.py
+++ b/qdtrack/datasets/pipelines/transforms.py
@@ -5,14 +5,18 @@ from mmdet.datasets.pipelines import Normalize, Pad, RandomFlip, Resize
 
 @PIPELINES.register_module()
 class SeqResize(Resize):
-
-    def __init__(self, *args, **kwargs):
+    def __init__(self, share_params=True, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.share_params = share_params
 
     def __call__(self, results):
-        outs = []
-        for _results in results:
+        outs, scale = [], None
+        for i, _results in enumerate(results):
+            if self.share_params and i > 0:
+                _results['scale'] = scale
             _results = super().__call__(_results)
+            if self.share_params and i == 0:
+                scale = _results['scale']
             outs.append(_results)
         return outs
 

--- a/qdtrack/models/losses/multipos_cross_entropy_loss.py
+++ b/qdtrack/models/losses/multipos_cross_entropy_loss.py
@@ -9,11 +9,27 @@ def multi_pos_cross_entropy(pred,
                             reduction='mean',
                             avg_factor=None):
     # element-wise losses
-    pos_inds = (label == 1).float()
-    neg_inds = (label == 0).float()
-    exp_pos = (torch.exp(-1 * pred) * pos_inds).sum(dim=1)
-    exp_neg = (torch.exp(pred.clamp(max=80)) * neg_inds).sum(dim=1)
-    loss = torch.log(1 + exp_pos * exp_neg)
+    # pos_inds = (label == 1).float()
+    # neg_inds = (label == 0).float()
+    # exp_pos = (torch.exp(-1 * pred) * pos_inds).sum(dim=1)
+    # exp_neg = (torch.exp(pred.clamp(max=80)) * neg_inds).sum(dim=1)
+    # loss = torch.log(1 + exp_pos * exp_neg)
+
+    # a more numerical stable implementation.
+    pos_inds = (label == 1)
+    neg_inds = (label == 0)
+    pred_pos = pred * pos_inds.float()
+    pred_neg = pred * neg_inds.float()
+    # use -inf to mask out unwanted elements.
+    pred_pos[neg_inds] = pred_pos[neg_inds] + float('inf')
+    pred_neg[pos_inds] = pred_neg[pos_inds] + float('-inf')
+
+    _pos_expand = torch.repeat_interleave(pred_pos, pred.shape[1], dim=1)
+    _neg_expand = pred_neg.repeat(1, pred.shape[1])
+
+    x = torch.nn.functional.pad((_neg_expand - _pos_expand), (0, 1), "constant", 0)
+    loss = torch.logsumexp(x, dim=1)
+
 
     # apply weights and do the reduction
     if weight is not None:

--- a/qdtrack/models/trackers/tao_tracker.py
+++ b/qdtrack/models/trackers/tao_tracker.py
@@ -159,21 +159,20 @@ class TaoTracker(object):
                     embeds,
                     memo_embeds,
                     method='dot_product',
-                    temperature=temperature,
-                    transpose=True)
+                    temperature=temperature)
                 cat_same = labels.view(-1, 1) == memo_labels.view(1, -1)
                 exps = torch.exp(sims) * cat_same.to(sims.device)
                 d2t_scores = exps / (exps.sum(dim=1).view(-1, 1) + 1e-6)
                 t2d_scores = exps / (exps.sum(dim=0).view(1, -1) + 1e-6)
                 cos_scores = cal_similarity(
-                    embeds, memo_embeds, method='cosine', transpose=True)
+                    embeds, memo_embeds, method='cosine')
                 cos_scores *= cat_same.to(cos_scores.device)
                 scores = (d2t_scores + t2d_scores) / 2
                 if self.match_with_cosine:
                     scores = (scores + cos_scores) / 2
             elif self.match_metric == 'cosine':
                 cos_scores = cal_similarity(
-                    embeds, memo_embeds, method='cosine', transpose=True)
+                    embeds, memo_embeds, method='cosine')
                 cat_same = labels.view(-1, 1) == memo_labels.view(1, -1)
                 scores = cos_scores * cat_same.float().to(cos_scores.device)
             else:


### PR DESCRIPTION
Fix the resize. The resize parameters for sequential frames should be consistent. Update the cal_similarity in tao_tracker to make it compatible with the current version.

Update a more numerical stable version of contrastive loss. 